### PR TITLE
fix(output): fix output rendering on GUI

### DIFF
--- a/packages/martian-robots-gui/src/app/app.tsx
+++ b/packages/martian-robots-gui/src/app/app.tsx
@@ -42,7 +42,7 @@ export function App() {
             </InputForm>
             <div>
               <h2>Output</h2>
-              <textarea disabled>{output}</textarea>
+              <textarea disabled value={output}></textarea>
             </div>
           </IOSection>
         </Card>


### PR DESCRIPTION
Fixes a bug where the output wouldn't populate in the output textarea (move from children to value)